### PR TITLE
Adding ability to pass a custom label component

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -149,6 +149,11 @@ class PlacesAutocomplete extends React.Component {
 
   renderLabel() {
     if (this.props.hideLabel) { return null }
+
+    if (React.isValidElement(this.props.label)) {
+      return this.props.label
+    }
+    
     return (<label style={this.props.styles.label} className={this.props.classNames.label || ''}>Location</label>)
   }
 

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -16,10 +16,25 @@ describe('<PlacesAutocomplete />', () => {
     expect(wrapper.find('input')).to.have.length(1)
   })
 
-  it('renderes an label element', () => {
+  it('renders an label element', () => {
     expect(wrapper.find('label')).to.have.length(1)
   })
 });
+
+describe('PlacesAutocomplete label', () => {
+  it('renders a custom label', () => {
+    const Label = <label>Custom Label</label>;
+
+    const wrapper = shallow(<PlacesAutocomplete 
+                        value="Akron, OH" 
+                        onChange={() => {}} 
+                        label={Label}
+                      />);
+
+    expect(wrapper.find('label')).to.have.length(1)
+  });
+});
+
 
 describe('PlacesAutocomplete callbacks', () => {
   it('calls componentDidMount', () => {


### PR DESCRIPTION
In `renderLabel` add the ability to pass a component, otherwise return the default label.

Still respects the `hideLabel` prop.