### PR TITLE
Added onFocus and onBlur configs for the input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ export default SimpleForm
 * clearItemsOnError
 * onSelect
 * onEnterKeyDown
+* onBlur
+* onFocus
 * options
 * autoFocus
 * inputName
@@ -305,6 +307,18 @@ const handleEnter = (address) => {
   onEnterKeyDown={this.handleEnter}
 />
 ```
+
+#### onBlur
+Type: `Function`,
+Required: `false`,
+
+You can pass `onBlur` prop to execute a function on the input's blur
+
+#### onFocus
+Type: `Function`,
+Required: `false`,
+
+You can pass `onFocus` prop to execute a function on the input's focus
 
 #### options
 Type: `Object`

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -22,6 +22,8 @@ const PlacesAutocomplete = (props) => {
 
 PlacesAutocomplete.propTypes = {
   value: React.PropTypes.string.isRequired,
+  onFocus: React.PropTypes.func,
+  onBlur: React.PropTypes.func,
   onChange: React.PropTypes.func.isRequired,
   onError: React.PropTypes.func,
   clearItemsOnError: React.PropTypes.bool,

--- a/src/PlacesAutocompleteBasic.js
+++ b/src/PlacesAutocompleteBasic.js
@@ -136,6 +136,15 @@ class PlacesAutocompleteBasic extends Component {
     }
   }
 
+  handleBlur(e) {
+    const { onBlur } = this.props;
+
+    if (onBlur) {
+      onBlur(e);
+    }
+    this.clearAutocomplete()
+  }
+
   setActiveItemAtIndex(index) {
     this.setState({
       autocompleteItems: this.state.autocompleteItems.map((item, idx) => {
@@ -188,7 +197,7 @@ class PlacesAutocompleteBasic extends Component {
   }
 
   renderInput() {
-    const { classNames, placeholder, styles, value, autoFocus, inputName, inputId } = this.props
+    const { classNames, placeholder, styles, value, autoFocus, inputName, inputId, onFocus } = this.props
     return (
       <input
         type="text"
@@ -197,7 +206,8 @@ class PlacesAutocompleteBasic extends Component {
         value={value}
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
-        onBlur={() => this.clearAutocomplete()}
+        onFocus={onFocus}
+        onBlur={e => this.handleBlur(e)}
         style={styles.input}
         autoFocus={autoFocus}
         name={inputName || ''}


### PR DESCRIPTION
I added two new configs, onFocus and onBlur to the autocomplete dropdown.  My motivation for making this change is that I wanted to automatically position the field at the top of the screen on focus, and to return the field on blur (similar to google's mobile site).

Note, I couldn't get the `npm run commit` command to work.  It kept blowing up while trying to find the pre-commit hook in my .git/hooks directory.