### PR TITLE
feat(accessibility): add visually hidden span with descriptive instru…

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -236,7 +236,12 @@ class PlacesAutocomplete extends Component {
         id="PlacesAutocomplete__root"
         style={this.inlineStyleFor('root')}
         className={this.classNameFor('root')}>
-        <input {...inputProps} />
+        <input {...inputProps} aria-describedby="PlacesAutocomplete__autocomplete-description"/>
+        <span 
+          id="PlacesAutocomplete__autocomplete-description"
+          style={this.inlineStyleFor('autocompleteDescription')}
+          className={this.classNameFor('autocompleteDescription')}
+        >Arrow down as you type for autocomplete suggestions.</span>
         {autocompleteItems.length > 0 && (
           <div
             id="PlacesAutocomplete__autocomplete-container"
@@ -281,13 +286,15 @@ PlacesAutocomplete.propTypes = {
     autocompleteContainer: PropTypes.string,
     autocompleteItem: PropTypes.string,
     autocompleteItemActive: PropTypes.string,
+    autocompleteDescription: PropTypes.string
   }),
   styles: PropTypes.shape({
     root: PropTypes.object,
     input: PropTypes.object,
     autocompleteContainer: PropTypes.object,
     autocompleteItem: PropTypes.object,
-    autocompleteItemActive: PropTypes.object
+    autocompleteItemActive: PropTypes.object,
+    autocompleteDescription: PropTypes.object
   }),
   options: PropTypes.shape({
     bounds: PropTypes.object,

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -239,7 +239,16 @@ class PlacesAutocomplete extends Component {
         <input {...inputProps} aria-describedby="PlacesAutocomplete__autocomplete-description"/>
         <span 
           id="PlacesAutocomplete__autocomplete-description"
-          style={this.inlineStyleFor('autocompleteDescription')}
+          style={{
+            position: 'absolute',
+            clip: 'rect(1px 1px 1px 1px)', /* IE6, IE7 */
+            clip: 'rect(1px, 1px, 1px, 1px)',
+            padding: '0',
+            border: '0',
+            height: '1px',
+            width: '1px',
+            overflow: 'hidden',
+          }}
           className={this.classNameFor('autocompleteDescription')}
         >Arrow down as you type for autocomplete suggestions.</span>
         {autocompleteItems.length > 0 && (
@@ -294,7 +303,6 @@ PlacesAutocomplete.propTypes = {
     autocompleteContainer: PropTypes.object,
     autocompleteItem: PropTypes.object,
     autocompleteItemActive: PropTypes.object,
-    autocompleteDescription: PropTypes.object
   }),
   options: PropTypes.shape({
     bounds: PropTypes.object,

--- a/src/defaultStyles.js
+++ b/src/defaultStyles.js
@@ -24,16 +24,6 @@ const defaultStyles = {
   autocompleteItemActive: {
     backgroundColor: '#fafafa'
   },
-  autocompleteDescription: {
-    position: 'absolute',
-    clip: 'rect(1px 1px 1px 1px)', /* IE6, IE7 */
-    clip: 'rect(1px, 1px, 1px, 1px)',
-    padding: '0',
-    border: '0',
-    height: '1px',
-    width: '1px',
-    overflow: 'hidden',
-  }
 }
 
 export default defaultStyles

--- a/src/defaultStyles.js
+++ b/src/defaultStyles.js
@@ -23,6 +23,16 @@ const defaultStyles = {
   },
   autocompleteItemActive: {
     backgroundColor: '#fafafa'
+  },
+  autocompleteDescription: {
+    position: 'absolute',
+    clip: 'rect(1px 1px 1px 1px)', /* IE6, IE7 */
+    clip: 'rect(1px, 1px, 1px, 1px)',
+    padding: '0',
+    border: '0',
+    height: '1px',
+    width: '1px',
+    overflow: 'hidden',
   }
 }
 


### PR DESCRIPTION
…ctions for screen reader use  a

In order to better support screen readers, a visually hidden span that instructs to arrow down as
you type for autocomplete suggestions. An aria-describedby attribute added to the input to direct to
the span description. a11y visually-hidden styles added to span to hide from sighted users.

issue #64