### PR TITLE
Add `filterPredictions` prop to optionally filter predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ export default SimpleForm
 * [`clearItemsOnError`](#clearItemsOnError)
 * [`onSelect`](#onSelect)
 * [`onEnterKeyDown`](#onEnterKeyDown)
+* [`filterPredictions`](#filterPredictions)
 * [`options`](#options)
 * [`debounce`](#debounce)
 * [`highlightFirstSuggestion`](#highlightFirstSuggestion)
@@ -329,7 +330,7 @@ const handleSelect = (address, placeId) => {
 #### onEnterKeyDown
 Type: `Function`
 Required: `false`
-Deafult: `noop`
+Default: `noop`
 
 You can pass a callback function that gets called when pressing down Enter key when no item in the dropdown is selected.  
 The function takes one argument, the value in the input field.
@@ -346,6 +347,25 @@ const handleEnter = (address) => {
 <PlacesAutocomplete
   inputProps={inputProps}
   onEnterKeyDown={this.handleEnter}
+/>
+```
+
+<a name="filterPredictions"></a>
+#### filterPredictions
+Type: `Function`
+Required: `false`
+Default: `null`
+
+You can pass a predicate function to filter the autocomplete predictions.
+This is helpful when you need more granularity than what's offered by the
+[`options`](#options) passed to the AutocompleteService class.
+
+```js
+const filterLocalities = (prediction) => prediction.types.includes('locality')
+
+<PlacesAutocomplete
+  inputProps={inputProps}
+  filterPredictions={filterLocalities}
 />
 ```
 

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -47,17 +47,20 @@ class PlacesAutocomplete extends Component {
       secondaryText: structured_formatting.secondary_text,
     })
 
-    const { highlightFirstSuggestion } = this.props
+    const { highlightFirstSuggestion, filterPredictions } = this.props
 
-    this.setState({
-      autocompleteItems: predictions.map((p, idx) => ({
-        suggestion: p.description,
-        placeId: p.place_id,
-        active: (highlightFirstSuggestion && idx === 0 ? true : false),
-        index: idx,
-        formattedSuggestion: formattedSuggestion(p.structured_formatting),
-      }))
-    })
+    const filteredPredictions = filterPredictions ?
+      predictions.filter(filterPredictions) : predictions
+
+    const autocompleteItems = filteredPredictions.map((p, idx) => ({
+      suggestion: p.description,
+      placeId: p.place_id,
+      active: (highlightFirstSuggestion && idx === 0 ? true : false),
+      index: idx,
+      formattedSuggestion: formattedSuggestion(p.structured_formatting),
+    }))
+
+    this.setState({ autocompleteItems })
   }
 
   fetchPredictions() {
@@ -307,6 +310,7 @@ PlacesAutocomplete.propTypes = {
   clearItemsOnError: PropTypes.bool,
   onSelect: PropTypes.func,
   autocompleteItem: PropTypes.func,
+  filterPredictions: PropTypes.func,
   classNames: PropTypes.shape({
     root: PropTypes.string,
     input: PropTypes.string,
@@ -346,6 +350,7 @@ PlacesAutocomplete.defaultProps = {
   onError: (status) => console.error('[react-places-autocomplete]: error happened when fetching data from Google Maps API.\nPlease check the docs here (https://developers.google.com/maps/documentation/javascript/places#place_details_responses)\nStatus: ', status),
   classNames: {},
   autocompleteItem: ({ suggestion }) => (<div>{suggestion}</div>),
+  filterPredictions: null,
   styles: {},
   options: {},
   debounce: 200,


### PR DESCRIPTION
When querying the API for predictions, the component's `option.types` allows to pass the type of prediction to be returned; however, that choice is limited to four pretty wide options.

If someone wants to have more granular control over what types of places they want to show up in the autocomplete results, they'll need to do some additional filtering on those results. The same can be said of other use-cases for filtering that can't be configured in the `option` prop.

This PR adds an optional prop to do just that: `filterPredictions` is a predicate function that gets called for each prediction, and which should return `true` for predictions that should be included, and `false` for those that shouldn't.

E.g. If I want to show autocomplete results that only contain sublocalities, I'll need to use both `option.types =
 ['(regions)']` (which returns localities, sublocalities, and other types) and `filterPredictions = (prediction) => prediction.types.includes('sublocality')`.

Additional filtering feels like a fairly common use-case: does this PR look like a good addition to you? Let me know if there's anything I can tweak on this PR before merging it!