### PR TITLE
feat: New localAddress prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ export default SimpleForm
 * [`options`](#options)
 * [`debounce`](#debounce)
 * [`highlightFirstSuggestion`](#highlightFirstSuggestion)
+* [`localAddress`](#localAddress)
 
 <a name="inputProps"></a>
 #### inputProps
@@ -379,6 +380,26 @@ Required: `false`
 Default: `false`
 
 If set to `true`, first suggestion in the dropdown will be automatically highlighted.
+
+<a name="localAddress"></a>
+#### localAddress
+Type: `String`
+Required: `false`
+Default: `''`
+
+You can add a default local address that will be displayed at the top of the dropdown:
+
+```js
+// default localAddress example
+render(){
+  return(
+    <PlacesAutocomplete
+      inputProps={inputProps}
+      localAddress{'Paris, France'}
+    />
+  )
+}
+```
 
 <a name="utility-functions"></a>
 ## Utility Functions

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -13,7 +13,7 @@ class PlacesAutocomplete extends Component {
   constructor(props) {
     super(props)
 
-    this.state = { autocompleteItems: [], localAddress: null }
+    this.state = { autocompleteItems: [], localAddress: null, localAddressString: '' }
 
     this.autocompleteCallback = this.autocompleteCallback.bind(this)
     this.handleInputKeyDown = this.handleInputKeyDown.bind(this)
@@ -33,7 +33,13 @@ class PlacesAutocomplete extends Component {
 
     this.autocompleteService = new google.maps.places.AutocompleteService()
     this.autocompleteOK = google.maps.places.PlacesServiceStatus.OK
-    this.handleLocalAddress()
+  }
+
+  componentWillReceiveProps(nextProps){
+    if(nextProps.localAddress != this.state.localAddressString){
+      this.setState({ localAddressString: nextProps.localAddress })
+      this.handleLocalAddress(nextProps.localAddress)
+    }
   }
 
   formattedSuggestion(structured_formatting) {
@@ -258,10 +264,8 @@ class PlacesAutocomplete extends Component {
     }
   }
 
-  handleLocalAddress(){
-    const address = this.props.localAddress
-
-    if(address === undefined || !address.length) return
+  handleLocalAddress(address){
+    if(address === null || address === undefined || !address.length) return
 
     this.autocompleteService.getPlacePredictions({
       ...this.props.options,
@@ -278,9 +282,18 @@ class PlacesAutocomplete extends Component {
           suggestion: p.description,
           placeId: p.place_id,
           index: 0,
-          formattedSuggestion: this.formattedSuggestion(p.structured_formatting)
+          formattedSuggestion: this.formattedSuggestion(p.structured_formatting),
+          localAddress: true
         }
       })
+    }
+  }
+
+  renderLocalAddressInfo(item){
+    if(item.localAddress != null){
+      return(
+        <div className={ 'local-address-additionnal-info' }></div>
+      )
     }
   }
 
@@ -305,9 +318,10 @@ class PlacesAutocomplete extends Component {
                 key={p.placeId}
                 onMouseOver={() => this.setActiveItemAtIndex(p.index)}
                 onMouseDown={() => this.selectAddress(p.suggestion, p.placeId)}
-                style={ p.active ? this.inlineStyleFor('autocompleteItem', 'autocompleteItemActive') :this.inlineStyleFor('autocompleteItem') }
+                style={ p.active ? this.inlineStyleFor('autocompleteItem', 'autocompleteItemActive') : this.inlineStyleFor('autocompleteItem') }
                 className={ p.active ? this.classNameFor('autocompleteItem', 'autocompleteItemActive') : this.classNameFor('autocompleteItem') }>
                 {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
+                {this.renderLocalAddressInfo(p)}
               </div>
             ))}
           </div>
@@ -338,7 +352,7 @@ PlacesAutocomplete.propTypes = {
     input: PropTypes.string,
     autocompleteContainer: PropTypes.string,
     autocompleteItem: PropTypes.string,
-    autocompleteItemActive: PropTypes.string,
+    autocompleteItemActive: PropTypes.string
   }),
   styles: PropTypes.shape({
     root: PropTypes.object,

--- a/src/defaultStyles.js
+++ b/src/defaultStyles.js
@@ -20,6 +20,7 @@ const defaultStyles = {
     padding: '10px',
     color: '#555555',
     cursor: 'pointer',
+    position: 'relative'
   },
   autocompleteItemActive: {
     backgroundColor: '#fafafa'

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -10,6 +10,27 @@ const testInputProps = {
   onChange: () => {},
 }
 
+const data = [
+  {
+    suggestion: 'San Francisco, CA',
+    placeId: 1,
+    active: false,
+    index: 0
+  },
+  {
+    suggestion: 'San Jose, CA',
+    placeId: 2,
+    active: false,
+    index: 1
+  },
+  {
+    suggestion: 'San Diego, CA',
+    placeId: 3,
+    active: false,
+    index: 2
+  }
+]
+
 /*** Enzyme Rocks ***/
 describe('<PlacesAutocomplete />', () => {
   let wrapper;
@@ -64,26 +85,6 @@ describe('autocomplete dropdown', () => {
   })
 
   it('renders autocomplete dropdown once it receives data from google maps', () => {
-    const data = [
-      {
-        suggestion: 'San Francisco, CA',
-        placeId: 1,
-        active: false,
-        index: 0
-      },
-      {
-        suggestion: 'San Jose, CA',
-        placeId: 2,
-        active: false,
-        index: 1
-      },
-      {
-        suggestion: 'San Diego, CA',
-        placeId: 3,
-        active: false,
-        index: 2
-      }
-    ]
     wrapper.setState({ autocompleteItems: data })
     expect(wrapper.find('#PlacesAutocomplete__autocomplete-container')).to.have.length(1)
     expect(wrapper.find('.autocomplete-item')).to.have.length(3)
@@ -112,6 +113,35 @@ describe('autocomplete dropdown', () => {
     wrapper.setState({ autocompleteItems: initialItems })
     wrapper.instance().autocompleteCallback([], 'ZERO_RESULTS')
     expect(wrapper.find('.autocomplete-item')).to.have.length(1)
+  })
+
+
+  // Possibility to add a custom/local address on top of google Predictions
+  it('adds the local address to the suggestions dropdown', () => {
+    const address = 'Paris, France'
+
+    //we mock the placesPrediction result
+    let mockedData = data.slice() //immutable array
+    mockedData.push(
+      {
+        suggestion: 'Paris, France',
+        placeId: 6,
+        active: false,
+        index: 4
+      }
+    )
+
+    wrapper.setState({ autocompleteItems: mockedData })
+    expect(wrapper.find('#PlacesAutocomplete__autocomplete-container')).to.have.length(1)
+    expect(wrapper.find('.autocomplete-item')).to.have.length(4)
+  })
+
+  it('does not add the local address to the suggestions dropdown', () => {
+    const address = 'invalidaddress'
+
+    wrapper.setState({ autocompleteItems: data })
+    expect(wrapper.find('#PlacesAutocomplete__autocomplete-container')).to.have.length(1)
+    expect(wrapper.find('.autocomplete-item')).to.have.length(3)
   })
 })
 
@@ -237,6 +267,7 @@ describe('autoFocus prop', () => {
     expect(wrapper.find('input').node).to.not.equal(document.activeElement)
   })
 })
+
 
 // TODOs:
 // * Test geocodeByAddress function


### PR DESCRIPTION
Possibility to add a new prop to the PlaceAutocomplete component: `localAddress`. This allow to set a default address at the top of the predictions dropdown. The new prop is an address string that will be geocoded to check it's validity, if it's valid it will be displayed.

The idea is to reproduce behaviour that you can see for exemple on airbnb within a search. 
The user come once and made a research for Paris, his search address is stored in localStorage. When the user will come back later, he will perform a search and he will see in the dropdown it's last search in Paris, even if he is searching for London. I want to be able to display the last user search at the same level as autocomplete predictions.

Of course it can be applied for whatever default address you need, the text above is just an example.