### PR TITLE
Bugfix/ie11 miss typed chars

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -227,12 +227,9 @@ class PlacesAutocomplete extends Component {
       type: "text",
     }
 
-    return {
+    let props = {
       ...defaultInputProps,
       ...this.props.inputProps,
-      onChange: (event) => {
-        this.handleInputChange(event)
-      },
       onKeyDown: (event) => {
         this.handleInputKeyDown(event)
       },
@@ -242,6 +239,12 @@ class PlacesAutocomplete extends Component {
       style: this.inlineStyleFor('input'),
       className: this.classNameFor('input'),
     }
+
+    // Detect IE11 -  IE 11 & React bug - Missing typed characters
+    props[!!window.MSInputMethodContext && !!document.documentMode ? 'onInput' : 'onChange'] = (event) => {
+      this.handleInputChange(event)
+    }
+    return props
   }
 
   render() {

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -239,10 +239,17 @@ class PlacesAutocomplete extends Component {
       style: this.inlineStyleFor('input'),
       className: this.classNameFor('input'),
     }
-
-    // Detect IE11 -  IE 11 & React bug - Missing typed characters
-    props[!!window.MSInputMethodContext && !!document.documentMode ? 'onInput' : 'onChange'] = (event) => {
-      this.handleInputChange(event)
+    // IE 11 & React bug - Missing typed characters
+    if(!!window.MSInputMethodContext && !!document.documentMode) {
+      // Is IE 11
+      props.onInput = (event) => {
+        this.handleInputChange(event)
+      }
+      delete props.onChange // Causes double call as inputProps still contains onChange
+    } else {
+      props.onChange = (event) => {
+        this.handleInputChange(event)
+      }
     }
     return props
   }


### PR DESCRIPTION
In IE 11 the input keeps missing characters while typing, this is a bug with React and IE11 which they hope to fix in React 16. For now I have pointed my app at this branch which uses onInput instead when on IE11, but you may also want to fix this for all other users and remove the workaround in future.

https://github.com/facebook/react/issues/7027
