### PR TITLE
(feat): Display autocomplete menu when down key hit

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -113,6 +113,7 @@ class PlacesAutocomplete extends Component {
 
   handleDownKey() {
     if (this.state.autocompleteItems.length === 0) {
+      this.debouncedFetchPredictions()
       return
     }
 


### PR DESCRIPTION
If the menu is hidden, fetch predictions and display the menu.

---

It's unexpected behavior - at least for me - to have to type to get the current results displayed. When the menu's collapsed and someone hits down, fetch items and show the menu.