### PR TITLE
Allow async loading of Google Maps Lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ export default SimpleForm
 * [`highlightFirstSuggestion`](#highlightFirstSuggestion)
 * [`googleLogo`](#googleLogo)
 * [`googleLogoType`](#googleLogoType)
+* [`googleApiUrl`](#googleApiUrl)
 
 <a name="inputProps"></a>
 #### inputProps
@@ -406,6 +407,15 @@ Default: `"default"`
 
 Allows you to pick right color theme for "powered by Google" logo.
 Please see Google's API page for more information: [https://developers.google.com/places/web-service/policies](https://developers.google.com/places/web-service/policies)
+
+<a name="googleApiUrl"></a>
+#### googleApiUrl
+Type: `String` ("default" or "inverse")
+Required: `false`
+Default: `null`
+
+Allows you to let the component include the Google Maps JavaScript API.
+
 
 <a name="utility-functions"></a>
 ## Utility Functions

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.8",
-    "react": "^15.3.0"
+    "react": "^15.3.0",
+    "scriptjs": "^2.5.8"
   }
 }

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -376,6 +376,7 @@ PlacesAutocomplete.propTypes = {
   highlightFirstSuggestion: PropTypes.bool,
   googleLogo: PropTypes.bool,
   googleLogoType: PropTypes.oneOf(["default", "inverse"]),
+  googleApiUrl: PropTypes.string
 }
 
 PlacesAutocomplete.defaultProps = {
@@ -389,6 +390,7 @@ PlacesAutocomplete.defaultProps = {
   highlightFirstSuggestion: false,
   googleLogo: true,
   googleLogoType: 'default',
+  googleApiUrl: null
 }
 
 export default PlacesAutocomplete

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -57,7 +57,7 @@ class PlacesAutocomplete extends Component {
     this.autocompleteService = new google.maps.places.AutocompleteService()
     this.autocompleteOK = google.maps.places.PlacesServiceStatus.OK
 
-    // If the component have be unmounted since we started loading the API, then we `setState`
+    // If the component have be unmounted since we started loading the API, then the `setState`
     // will fail, so we exit
     if (this.isUnmounted) return;
 


### PR DESCRIPTION
This fixes #57 by having a prop `googleMapUrl` and letting the component load the library.

While the library is loading it will have the `<input/>` disabled.

It add a dependency on scriptjs.

I am not very experienced in JS/React testing, so I have not made any.. I tried the using the method on the /demo and it worked.

It should not break existing components unless they have a prop named `googleApiUrl`