### PR TITLE
add list of autocomplete items in onEnterKeyDown callback's parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,11 @@ Type: `Function`
 Required: `false`
 Deafult: `noop`
 
-You can pass a callback function that gets called when pressing down Enter key when no item in the dropdown is selected.  
-The function takes one argument, the value in the input field.
+You can pass a callback function that gets called when pressing down Enter key when no item in the dropdown is selected.
+The function takes two arguments, the value in the input field and the current list of autocomplete items.
 
 ```js
-const handleEnter = (address) => {
+const handleEnter = (address, autocompleteItems) => {
   geocodeByAddress(address)
     .then(results => {
       console.log('results', results)

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -104,7 +104,7 @@ class PlacesAutocomplete extends Component {
 
   handleEnterKeyWithoutActiveItem() {
     if (this.props.onEnterKeyDown) {
-      this.props.onEnterKeyDown(this.props.inputProps.value)
+      this.props.onEnterKeyDown(this.props.inputProps.value, this.state.autocompleteItems)
       this.clearAutocomplete()
     } else {
       return //noop


### PR DESCRIPTION
Hi,

I need to be able to use the list of items in my `onEnterKeyDown` callback function.
Indeed, some of the users just press enter when they see their address in first position of propositions, and the current functionality only allow me to use the uncompleted address.

I need this in order to do something like this: 
```js
const handleEnter = (address, autocompleteItems) => {
  const possibleAddress = autocompleteItems && autocompleteItems[0] && autocompleteItems[0].suggestion;
  geocodeByAddress(possibleAddress || address)
    .then(results => {
      console.log('results', results)
    })
}
```
TL;DR
If the user press enter, use the first (or any) proposition (if exists), or the actual input otherwise