### PR TITLE
add alwaysRenderSuggestion prop

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -71,6 +71,9 @@ class PlacesAutocomplete extends Component {
   }
 
   clearAutocomplete() {
+    if (this.props.alwaysRenderSuggestion) {
+      return;
+    }
     this.setState({ autocompleteItems: [] })
   }
 


### PR DESCRIPTION
Related to https://github.com/kenny-hibino/react-places-autocomplete/issues/126.

This solution worked perfectly for me for debugging style issues, no default props were needed, could just type something in to get suggestion box open then inspect styles just fine. 

If you're happy to accept this, I'll happily add some documentation around it. 