### PR TITLE
feat(component): Add children rendering to component

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -168,6 +168,9 @@ class PlacesAutocomplete extends Component {
         event.preventDefault()
         this.handleEnterKey()
         break
+      case 'Tab':
+        this.handleEnterKey() // Let Tab go to next field
+        break
       case 'ArrowDown':
         event.preventDefault() // prevent the cursor from moving
         this.handleDownKey()

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -277,6 +277,7 @@ class PlacesAutocomplete extends Component {
         className={this.classNameFor('root')}
       >
         <input {...inputProps} />
+        {this.props.children}
         {autocompleteItems.length > 0 && (
           <div
             id="PlacesAutocomplete__autocomplete-container"


### PR DESCRIPTION
Add children rendering to PlacesAutoComplete. This is needed to be used with
material-web-components' TextField.

Material Web Components require the `label` and and extra div for the bottom line to be in the same div as the input.

```
      <div className={cx('autocomplete-text-field', 'form-text-field__input')}>
        <PlacesAutoComplete
          inputProps={{ ...inputProps, value: input.value, onChange: input.onChange, id: 'places-autocomplete' }}
          options={autocompleteOptions}
          classNames={{
            root: 'mdc-text-field places-autocomplete-mdc-field form-text-field',
            input: `mdc-text-field__input ${className}`,
          }}
        >
          {!!label && (
            <TextFieldLabel htmlFor="places-autocomplete">{label}</TextFieldLabel>
          )}
          <TextFieldBottomLine/>
        </PlacesAutoComplete>
      </div>
```