### PR TITLE
Feat: Add rows property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ export default SimpleForm
 |[`debounce`](#debounce) | number | | Number of milliseconds to delay before making a call to Google Maps API |
 | [`highlightFirstSuggestion`](#highlightFirstSuggestion) | boolean | | If set to `true`, first list item in the dropdown will be automatically highlighted |
 |[`shouldFetchSuggestions`](#shouldFetchSuggestions)| function | | Component will fetch suggestions from Google Maps API only when this function returns `true` |
+|[`rows`](#rows)| number | | If greater than 1, will render `textarea` instead of `input` with {rows} number of rows. |
 
 <a name="inputProps"></a>
 #### inputProps
@@ -428,6 +429,14 @@ const shouldFetchSuggestions = ({ value }) => value.length > 3
   shouldFetchSuggestions={shouldFetchSuggestions}
 />
 ```
+
+<a name="rows"></a>
+#### rows
+Type: `Number`
+Required: `false`
+Default: `1`
+
+If greater than 1, will render `textarea` instead of `input` with {rows} number of rows.
 
 <a name="utility-functions"></a>
 ## Utility Functions

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -329,6 +329,7 @@ class PlacesAutocomplete extends Component {
   }
 
   render() {
+    const { rows } = this.props;
     const { autocompleteItems } = this.state;
     const inputProps = this.getInputProps();
 
@@ -338,7 +339,10 @@ class PlacesAutocomplete extends Component {
         style={this.inlineStyleFor('root')}
         className={this.classNameFor('root')}
       >
-        <input {...inputProps} />
+        {rows > 1
+          ? <textarea {...inputProps} rows={rows} />
+          : <input {...inputProps} />
+        }
         {this.shouldRenderDropdown() && (
           <div
             role="listbox"
@@ -433,6 +437,7 @@ PlacesAutocomplete.propTypes = {
   highlightFirstSuggestion: PropTypes.bool,
   renderFooter: PropTypes.func,
   shouldFetchSuggestions: PropTypes.func.isRequired,
+  rows: PropTypes.number,
 };
 
 PlacesAutocomplete.defaultProps = {
@@ -450,6 +455,7 @@ PlacesAutocomplete.defaultProps = {
   debounce: 200,
   highlightFirstSuggestion: false,
   shouldFetchSuggestions: () => true,
+  rows: 1,
 };
 
 export default PlacesAutocomplete;

--- a/src/defaultStyles.js
+++ b/src/defaultStyles.js
@@ -7,6 +7,7 @@ const defaultStyles = {
     display: 'inline-block',
     width: '100%',
     padding: '10px',
+    resize: 'none',
   },
   autocompleteContainer: {
     position: 'absolute',


### PR DESCRIPTION
As issued in #32 and #130 and already tried in #69, this adds an optional `rows` property, which allows to select the amount of rows. When `rows` is greater than 1, a `textarea` is used instead of `input`. The default is `1`.