### PR TITLE
onSelect also passes selected suggestion

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -125,10 +125,10 @@ class PlacesAutocomplete extends React.Component {
     });
   };
 
-  handleSelect = (address, placeId) => {
+  handleSelect = (address, placeId, suggestion) => {
     this.clearSuggestions();
     if (this.props.onSelect) {
-      this.props.onSelect(address, placeId);
+      this.props.onSelect(address, placeId, suggestion);
     } else {
       this.props.onChange(address);
     }
@@ -154,9 +154,9 @@ class PlacesAutocomplete extends React.Component {
   handleEnterKey = () => {
     const activeSuggestion = this.getActiveSuggestion();
     if (activeSuggestion === undefined) {
-      this.handleSelect(this.props.value, null);
+      this.handleSelect(this.props.value, null, null);
     } else {
-      this.handleSelect(activeSuggestion.description, activeSuggestion.placeId);
+      this.handleSelect(activeSuggestion.description, activeSuggestion.placeId, activeSuggestion);
     }
   };
 
@@ -347,7 +347,7 @@ class PlacesAutocomplete extends React.Component {
       event.preventDefault();
     }
     const { description, placeId } = suggestion;
-    this.handleSelect(description, placeId);
+    this.handleSelect(description, placeId, suggestion);
     setTimeout(() => {
       this.mousedownOnSuggestion = false;
     });

--- a/src/tests/onSelectProp.test.js
+++ b/src/tests/onSelectProp.test.js
@@ -30,7 +30,7 @@ describe('onSelect prop', () => {
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     // first argument is input value,
     // second argument is placeId, null in this case.
-    expect(onSelectHandler).toBeCalledWith('San Francisco', null);
+    expect(onSelectHandler).toBeCalledWith('San Francisco', null, null);
   });
 
   test('pressing Enter when one of the suggestion items is active', () => {
@@ -46,7 +46,8 @@ describe('onSelect prop', () => {
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     expect(onSelectHandler).toBeCalledWith(
       mockSuggestions[0].description,
-      mockSuggestions[0].placeId
+      mockSuggestions[0].placeId,
+      expect.objectContaining({ id: mockSuggestions[0].id })
     );
   });
 
@@ -66,7 +67,8 @@ describe('onSelect prop', () => {
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     expect(onSelectHandler).toBeCalledWith(
       mockSuggestions[0].description,
-      mockSuggestions[0].placeId
+      mockSuggestions[0].placeId,
+      expect.objectContaining({ id: mockSuggestions[0].id })
     );
   });
 });


### PR DESCRIPTION
In order to minimize our need to parse the result, we want the original suggestion from google. (For example to get the main and secondary text as separate fields).