### PR TITLE
fix: Use unique ids for each suggestion

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -243,11 +243,11 @@ class PlacesAutocomplete extends React.Component {
     }
   };
 
+  formatSuggestionId = suggestion => `PlacesAutocomplete__suggestion-${suggestion.placeId}`;
+
   getActiveSuggestionId = () => {
     const activeSuggestion = this.getActiveSuggestion();
-    return activeSuggestion
-      ? `PlacesAutocomplete__suggestion-${activeSuggestion.placeId}`
-      : undefined;
+    return activeSuggestion ? this.formatSuggestionId(activeSuggestion) : undefined;
   };
 
   getIsExpanded = () => {
@@ -302,7 +302,7 @@ class PlacesAutocomplete extends React.Component {
     return {
       ...options,
       key: suggestion.id,
-      id: this.getActiveSuggestionId(),
+      id: this.formatSuggestionId(suggestion),
       role: 'option',
       onMouseEnter: compose(handleSuggestionMouseEnter, options.onMouseEnter),
       onMouseLeave: compose(

--- a/src/tests/mouseEvents.test.js
+++ b/src/tests/mouseEvents.test.js
@@ -6,7 +6,7 @@ beforeAll(() => {
 });
 
 describe('mouse event handlers', () => {
-  test('suggesion item handles mouse enter and leave event', () => {
+  test('suggestion item handles mouse enter and leave event', () => {
     const wrapper = mountComponent();
     simulateSearch(wrapper);
 
@@ -20,5 +20,15 @@ describe('mouse event handlers', () => {
     suggestionItem.simulate('mouseleave');
     suggestions = wrapper.state().suggestions;
     expect(suggestions[0].active).toEqual(false);
+  });
+
+  test('suggestion item should have a unique id on mouse enter', () => {
+    const wrapper = mountComponent();
+    simulateSearch(wrapper);
+
+    wrapper.find('[data-test="suggestion-item"]').forEach(suggestion => {
+      const suggestionId = suggestion.prop('id');
+      expect(wrapper.find(`#${suggestionId}`).length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
**Summary**

Currently, on the mouseover event, each suggestion updates its id to be the active suggestion's id.
Each suggestion should have a unique id (this is a best practice and is also necessary for ARIA
compliance). This uses the specific suggestion's Google place id as part of the id so that each one
is unique.

First, thanks for all the work on this! I was running through our app using `react-axe` and noticed that when hovering over suggestions there was the following error: [IDs used in ARIA and labels must be unique](https://dequeuniversity.com/rules/axe/3.2/duplicate-id-aria?application=axeAPI). When inspecting the DOM, I noticed that when hovering over each suggestion that the `id` attribute would update to be the Google place id of the active/hovered suggestion.

Let me know if I'm missing something, or if I need to update anything. Thanks!