### PR TITLE
Add test coverage for getLatLng

### DIFF
--- a/src/tests/__snapshots__/utils.test.js.snap
+++ b/src/tests/__snapshots__/utils.test.js.snap
@@ -46,8 +46,8 @@ Array [
         "west": -123.17382499999997,
       },
       "location": Object {
-        "lat": 37.7749295,
-        "lng": -122.41941550000001,
+        "lat": [Function],
+        "lng": [Function],
       },
       "location_type": "APPROXIMATE",
       "viewport": Object {
@@ -112,8 +112,8 @@ Array [
         "west": -123.17382499999997,
       },
       "location": Object {
-        "lat": 37.7749295,
-        "lng": -122.41941550000001,
+        "lat": [Function],
+        "lng": [Function],
       },
       "location_type": "APPROXIMATE",
       "viewport": Object {

--- a/src/tests/helpers/googlePayloads.js
+++ b/src/tests/helpers/googlePayloads.js
@@ -31,7 +31,7 @@ export const GEOCODE_RESULT = {
           north: 37.9298239,
           east: -122.28178000000003,
         },
-        location: { lat: 37.7749295, lng: -122.41941550000001 },
+        location: { lat: () => 37.7749295, lng: () => -122.41941550000001 },
         location_type: 'APPROXIMATE',
         viewport: {
           south: 37.70339999999999,

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -1,5 +1,6 @@
-import { geocodeByAddress, geocodeByPlaceId } from '../utils';
+import { geocodeByAddress, geocodeByPlaceId, getLatLng } from '../utils';
 import { setupGoogleMock } from './helpers/setup';
+import { GEOCODE_RESULT } from './helpers/googlePayloads';
 
 beforeAll(() => {
   setupGoogleMock();
@@ -21,6 +22,34 @@ describe('geocodeByAddress', () => {
   });
 });
 
+describe('getLatLng', () => {
+  describe('getting the lat and lng of a valid result', () => {
+    it('resolves to the correct latLng object', () => {
+      const result = GEOCODE_RESULT['San Francisco'][0]
+
+      expect.assertions(1);
+      /* lat and lng of San Francisco */
+      return getLatLng(result).then(latLng => {
+        expect(latLng).toEqual({
+          lat: 37.7749295,
+          lng: -122.41941550000001,
+        });
+      });
+    });
+  });
+
+  describe('getting the lat and lang of an invalid result', () => {
+    it('rejects the invalid result', () => {
+      const result = {};
+
+      expect.assertions(1);
+      return getLatLng(result).catch(error => {
+        expect(error).toBeDefined();
+      });
+    });
+  });
+});
+
 describe('geocodeByPlaceId', () => {
   it('geocode valid placeID', () => {
     expect.assertions(1);
@@ -30,5 +59,3 @@ describe('geocodeByPlaceId', () => {
     });
   });
 });
-
-/* TODO: test getLatLng */


### PR DESCRIPTION
**Summary**

This PR alters the `GEOCODE_RESULT` object to better fall in with what google actually sends back as a result.

https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLng

After fixing that I wrote tests that would have otherwise been testing a false positive for the `getLatLng` function.

I tried to use the commit command that is listed in contributing and I got some errors back. I decided to just write my own.

Thanks for writing this package.
