### PR TITLE
Fix check for google places loaded

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -35,7 +35,9 @@ class PlacesAutocomplete extends React.Component {
   componentDidMount() {
     const { googleCallbackName } = this.props;
     if (googleCallbackName) {
-      if (!window.google) {
+      const isPlacesLoaded =
+        window.google && window.google.maps && window.google.maps.places;
+      if (!isPlacesLoaded) {
         window[googleCallbackName] = this.init;
       } else {
         this.init();


### PR DESCRIPTION
# Description
When checking to see if google places has loaded during async setup using the `googleCallbackName ` there is a little bug.

Issue: 
Was checking for `window.google`. The bug shows up because there are other services that make `window.google` true. For example loading ads `window.google.ads`

Fix:
Explicitly check that places exists `window.google.maps.places`