### PR TITLE
Have raw suggestion object be one of the arguments of onSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,12 @@ Default: `null`
 You can pass a function that gets called instead of `onChange` function when user
 hits the Enter key or clicks on a suggestion item.
 
-The function takes two positional arguments. First argument is `address`, second is `placeId`.
+The function takes three positional arguments. First argument is `address`, second is `placeId` and third is the entire `suggestion` object.
 
 ```js
-// NOTE: `placeId` is null when user hits Enter key with no suggestion item selected.
-const handleSelect = (address: string, placeId: ?string) => {
-  // Do something with address and placeId
+// NOTE: `placeId` and `suggestion` are null when user hits Enter key with no suggestion item selected.
+const handleSelect = (address: string, placeId: ?string, suggestion: ?object) => {
+  // Do something with address and placeId and suggestion
 }
 
 // Pass this function via onSelect prop.

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -88,7 +88,7 @@ class PlacesAutocomplete extends React.Component {
         id: p.id,
         description: p.description,
         placeId: p.place_id,
-        active: highlightFirstSuggestion && idx === 0 ? true : false,
+        active: highlightFirstSuggestion && idx === 0,
         index: idx,
         formattedSuggestion: formattedSuggestion(p.structured_formatting),
         matchedSubstrings: p.matched_substrings,

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -125,10 +125,10 @@ class PlacesAutocomplete extends React.Component {
     });
   };
 
-  handleSelect = (address, placeId) => {
+  handleSelect = (address, placeId, suggestion) => {
     this.clearSuggestions();
     if (this.props.onSelect) {
-      this.props.onSelect(address, placeId);
+      this.props.onSelect(address, placeId, suggestion);
     } else {
       this.props.onChange(address);
     }
@@ -154,9 +154,13 @@ class PlacesAutocomplete extends React.Component {
   handleEnterKey = () => {
     const activeSuggestion = this.getActiveSuggestion();
     if (activeSuggestion === undefined) {
-      this.handleSelect(this.props.value, null);
+      this.handleSelect(this.props.value, null, null);
     } else {
-      this.handleSelect(activeSuggestion.description, activeSuggestion.placeId);
+      this.handleSelect(
+        activeSuggestion.description,
+        activeSuggestion.placeId,
+        activeSuggestion
+      );
     }
   };
 
@@ -347,7 +351,7 @@ class PlacesAutocomplete extends React.Component {
       event.preventDefault();
     }
     const { description, placeId } = suggestion;
-    this.handleSelect(description, placeId);
+    this.handleSelect(description, placeId, suggestion);
     setTimeout(() => {
       this.mousedownOnSuggestion = false;
     });

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -88,7 +88,7 @@ class PlacesAutocomplete extends React.Component {
         id: p.id,
         description: p.description,
         placeId: p.place_id,
-        active: highlightFirstSuggestion && idx === 0,
+        active: highlightFirstSuggestion && idx === 0 ? true : false,
         index: idx,
         formattedSuggestion: formattedSuggestion(p.structured_formatting),
         matchedSubstrings: p.matched_substrings,

--- a/src/tests/helpers/testHelpers.js
+++ b/src/tests/helpers/testHelpers.js
@@ -97,7 +97,7 @@ export const mockSuggestions = [
 /**
  * Simulates User typing 'San Francisco' in input,
  * and getting results back from Google Maps API,
- * populating `suggesions` state.
+ * populating `suggestions` state.
  */
 export const simulateSearch = wrapper => {
   const input = wrapper.find('input');

--- a/src/tests/onSelectProp.test.js
+++ b/src/tests/onSelectProp.test.js
@@ -30,7 +30,7 @@ describe('onSelect prop', () => {
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     // first argument is input value,
     // second argument is placeId, null in this case.
-    expect(onSelectHandler).toBeCalledWith('San Francisco', null);
+    expect(onSelectHandler).toBeCalledWith('San Francisco', null, null);
   });
 
   test('pressing Enter when one of the suggestion items is active', () => {
@@ -38,15 +38,22 @@ describe('onSelect prop', () => {
     const wrapper = mountComponent({
       onSelect: onSelectHandler,
     });
-    simulateSearch(wrapper); // suggestions state is populated by mockSuggestions
 
+    simulateSearch(wrapper); // suggestions state is populated by mockSuggestions
     const input = wrapper.find('input');
     input.simulate('keydown', { key: 'ArrowDown' }); // index 0 active
     input.simulate('keydown', { key: 'Enter' });
+
+    const activeMockSuggestion = {
+      ...mockSuggestions[0],
+      active: true,
+    };
+
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     expect(onSelectHandler).toBeCalledWith(
-      mockSuggestions[0].description,
-      mockSuggestions[0].placeId
+      activeMockSuggestion.description,
+      activeMockSuggestion.placeId,
+      activeMockSuggestion
     );
   });
 
@@ -55,18 +62,51 @@ describe('onSelect prop', () => {
     const wrapper = mountComponent({
       onSelect: onSelectHandler,
     });
-    simulateSearch(wrapper);
 
+    simulateSearch(wrapper);
     const suggestionItem = wrapper
       .find('[data-test="suggestion-item"]')
       .first();
     const input = wrapper.find('input');
     suggestionItem.simulate('mouseenter');
     input.simulate('keydown', { key: 'Enter' });
+
+    const activeMockSuggestion = {
+      ...mockSuggestions[0],
+      active: true,
+    };
+
     expect(onSelectHandler).toHaveBeenCalledTimes(1);
     expect(onSelectHandler).toBeCalledWith(
-      mockSuggestions[0].description,
-      mockSuggestions[0].placeId
+      activeMockSuggestion.description,
+      activeMockSuggestion.placeId,
+      activeMockSuggestion
+    );
+  });
+
+  test('clicking on a suggestion will call onSelect handler with the correct arguments', () => {
+    const onSelectHandler = jest.fn();
+    const wrapper = mountComponent({
+      onSelect: onSelectHandler,
+    });
+
+    simulateSearch(wrapper);
+    const suggestionItem = wrapper
+      .find('[data-test="suggestion-item"]')
+      .first();
+    suggestionItem.simulate('mouseenter');
+    suggestionItem.simulate('click');
+
+    const activeMockSuggestion = {
+      ...mockSuggestions[0],
+      active: true,
+    };
+
+    expect(onSelectHandler).toHaveBeenCalledTimes(1);
+    expect(onSelectHandler).toBeCalledWith(
+      activeMockSuggestion.description,
+      activeMockSuggestion.placeId,
+      activeMockSuggestion
     );
   });
 });


### PR DESCRIPTION
**Summary**
Sometimes it's useful to have access to the entire suggestion object inside a onSelect. Fore example to differentiate between `mainText` and `secondaryText` or to use the type without waiting for a Places API response.

The changes i've made are backwards compatible, as they add a third argument to the onSelect function and can be ommited in the respective handler.



An example of a suggestion object:
```js
{
  "selected": "Berlin, Germany",
  "placeId": "ChIJAVkDPzdOqEcRcDteW0YgIQQ",
  "suggestion": {
    "id": "6b1afbd7fcf2ec16ff8e2f95514e2badb8c2451d",
    "description": "Berlin, Germany",
    "placeId": "ChIJAVkDPzdOqEcRcDteW0YgIQQ",
    "active": true,
    "index": 0,
    "formattedSuggestion": {
      "mainText": "Berlin",
      "secondaryText": "Germany"
    },
    "matchedSubstrings": [
      {
        "length": 6,
        "offset": 0
      }
    ],
    "terms": [
      {
        "offset": 0,
        "value": "Berlin"
      },
      {
        "offset": 8,
        "value": "Germany"
      }
    ],
    "types": [
      "locality",
      "political",
      "geocode"
    ]
  }
}

```

