### PR TITLE
#152 nullsafe objprop access

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,7 @@ export const compose = (...fns) => (...args) => {
 
 export const pick = (obj, ...props) => {
   return props.reduce((newObj, prop) => {
-    if (obj.hasOwnProperty(prop)) {
+    if (obj && obj.hasOwnProperty(prop)) {
       newObj[prop] = obj[prop];
     }
     return newObj;


### PR DESCRIPTION
Very minor change to hopefully avoid the error message mentioned in https://github.com/hibiken/react-places-autocomplete/issues/152

It's just adding an `obj &&` check before invoking `hawOwnProperty()` on that object.