### PR TITLE
fix(browser): Change the `key` prop on list children to be unique.

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -307,7 +307,7 @@ class PlacesAutocomplete extends React.Component {
 
     return {
       ...options,
-      key: suggestion.id,
+      key: suggestion.placeId,
       id: this.getActiveSuggestionId(),
       role: 'option',
       onMouseEnter: compose(handleSuggestionMouseEnter, options.onMouseEnter),


### PR DESCRIPTION
The `key` prop is currently based on the suggestion's `id`. That's not guaranteed to be present and
is often `undefined`, breaking the uniqueness constraint.Fixes the warning in the browser console:
`Warning: Each child in a list should have a unique "key" prop`.

[Fixes #335]
