### PR TITLE
fix: 🐛 suggestions now appear after minimum value set #387

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -233,14 +233,15 @@ class PlacesAutocomplete extends React.Component {
   handleInputChange = event => {
     const { value } = event.target;
     this.props.onChange(value);
-    this.setState({ userInputValue: value });
-    if (!value) {
-      this.clearSuggestions();
-      return;
-    }
-    if (this.props.shouldFetchSuggestions) {
-      this.debouncedFetchPredictions();
-    }
+    this.setState({ userInputValue: value }, () => {
+      if (!value) {
+        this.clearSuggestions();
+        return;
+      }
+      if (this.props.shouldFetchSuggestions) {
+        this.debouncedFetchPredictions();
+      }
+    });
   };
 
   handleInputOnBlur = () => {


### PR DESCRIPTION
✅ Closes: #387

**Summary**

Fix "shouldFetchSuggestions" bug where suggestions only appear after the 4th character is entered.

Before fix

https://user-images.githubusercontent.com/33280888/212497736-cb3692d5-69fc-460a-847a-bfca91583e48.mov

After fix

https://user-images.githubusercontent.com/33280888/212497763-b5b3b7a4-29ae-48f4-a9cd-99c2bc7fb41d.mov


